### PR TITLE
 서버 실행 시 MediaPipe 초기화 오류 방지

### DIFF
--- a/Vision/vision.py
+++ b/Vision/vision.py
@@ -27,12 +27,18 @@ latest_frame = None
 latest_data = {"error": "camera off"}
 lock = threading.Lock()
 
-# --- Mediapipe 초기화 ---
+# --- Mediapipe 초기화 (카메라 시작 후 lazy loading) ---
 mp_face_mesh = mp.solutions.face_mesh
-face_mesh = mp_face_mesh.FaceMesh(
-    max_num_faces=1,
-    refine_landmarks=True
-)
+face_mesh = None
+
+def _get_face_mesh():
+    global face_mesh
+    if face_mesh is None:
+        face_mesh = mp_face_mesh.FaceMesh(
+            max_num_faces=1,
+            refine_landmarks=True
+        )
+    return face_mesh
 
 def calculate_ear(landmarks, eye_indices, w, h):
     points = []
@@ -98,6 +104,8 @@ def _capture_loop():
     last_save_time = 0
 
     while is_running:
+        face_mesh_model = _get_face_mesh()
+
         if cap is None or not cap.isOpened():
             time.sleep(0.1)
             continue
@@ -109,7 +117,7 @@ def _capture_loop():
 
         h, w, _ = frame.shape
         rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-        results = face_mesh.process(rgb)
+        results = face_mesh_model.process(rgb)
 
         # 거북목 감지 (같은 rgb 프레임 재사용 - 추가 변환 없음)
         neck_data = neck_detector.update(rgb)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ opencv-python
 mediapipe==0.10.9
 numpy
 flask
+flask-socketio
 
-
-Python 3.11 사용 권장
+# Python 3.11 사용 권장


### PR DESCRIPTION
  - Vision/vision.py에서 FaceMesh를 import 시점에 바 로 초기화하던 구조를 수정
  - 카메라 캡처 루프가 실제 실행될 때 lazy loading 방 식으로 초기화되도록 변경
  - 이로 인해 Backend.server import 단계에서 OpenGL/ MediaPipe 오류로 서버가 죽는 문제 완화

  의존성 누락 수정

  - requirements.txt에 flask-socketio 추가
  - 서버 코드에서 flask_socketio를 사용하지만 설치 목 록에 없어 새 환경에서 실행 실패 가능성이 있었음

  requirements 문법 정리

  - Python 3.11 사용 권장 문구를 pip가 무시할 수 있도 록 주석 처리
  - 기존 상태에서는 requirements 파일로 설치 시 잘못 된 패키지명처럼 해석될 수 있었음